### PR TITLE
Dependency and submodule fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,22 +3,22 @@
 	url = https://gitlab.com/libeigen/eigen.git
 [submodule "worldgen/terrain/gen_occlusions/dependencies/argparse"]
 	path = process_mesh/dependencies/argparse
-	url = git@github.com:p-ranav/argparse.git
+	url = https://github.com/p-ranav/argparse.git
 [submodule "worldgen/terrain/gen_occlusions/dependencies/cnpy"]
 	path = process_mesh/dependencies/cnpy
-	url = git@github.com:rogersce/cnpy.git
+	url = https://github.com/rogersce/cnpy.git
 [submodule "worldgen/terrain/gen_occlusions/dependencies/indicators"]
 	path = process_mesh/dependencies/indicators
-	url = git@github.com:p-ranav/indicators.git
+	url = https://github.com/p-ranav/indicators.git
 [submodule "worldgen/terrain/gen_occlusions/dependencies/tinycolormap"]
 	path = process_mesh/dependencies/tinycolormap
-	url = git@github.com:yuki-koyama/tinycolormap.git
+	url = https://github.com/yuki-koyama/tinycolormap.git
 [submodule "worldgen/terrain/gen_occlusions/dependencies/glm"]
 	path = process_mesh/dependencies/glm
-	url = git@github.com:g-truc/glm.git
+	url = https://github.com/g-truc/glm.git
 [submodule "worldgen/terrain/gen_occlusions/dependencies/fast_obj"]
 	path = process_mesh/dependencies/fast_obj
-	url = git@github.com:thisistherk/fast_obj.git
+	url = https://github.com/thisistherk/fast_obj.git
 [submodule "process_mesh/dependencies/json"]
 	path = process_mesh/dependencies/json
 	url = https://github.com/nlohmann/json.git

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ If you use Infinigen in your work, please cite our [academic paper](https://arxi
 ## Requirements:
 
 - Debian/Ubuntu
-  - g++, [conda](https://docs.conda.io/en/latest/)
+  - g++
+  - [conda](https://docs.conda.io/en/latest/)
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -16,15 +16,29 @@ If you use Infinigen in your work, please cite our [academic paper](https://arxi
 ```
 ## Requirements:
 
-- Debian/Ubuntu
-  - g++
-  - [conda](https://docs.conda.io/en/latest/)
-  - libglm-dev
-  - libxi6
-  - libgconf-2-4
-  - libxxf86vm-dev
-  - libxfixes-dev
+#### Debian/Ubuntu:
 
+- [Conda](https://docs.conda.io/en/latest/)
+
+```
+sudo apt install build-essential \
+git \
+subversion \
+cmake \
+libx11-dev \
+libxxf86vm-dev \
+libxcursor-dev \
+libxi-dev \
+libxrandr-dev \
+libxinerama-dev \
+libegl-dev \
+libwayland-dev \
+wayland-protocols \
+libxkbcommon-dev \
+libdbus-1-dev \
+linux-libc-dev
+```
+---
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ If you use Infinigen in your work, please cite our [academic paper](https://arxi
   year={2023}
 }
 ```
+## Requirements:
+
+- Debian/Ubuntu
+  - g++, [conda](https://docs.conda.io/en/latest/)
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ If you use Infinigen in your work, please cite our [academic paper](https://arxi
   - g++
   - [conda](https://docs.conda.io/en/latest/)
   - libglm-dev
+  - libxi6
+  - libgconf-2-4
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you use Infinigen in your work, please cite our [academic paper](https://arxi
   - libxi6
   - libgconf-2-4
   - libxxf86vm-dev
+  - libxfixes-dev
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you use Infinigen in your work, please cite our [academic paper](https://arxi
 - Debian/Ubuntu
   - g++
   - [conda](https://docs.conda.io/en/latest/)
+  - libglm-dev
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you use Infinigen in your work, please cite our [academic paper](https://arxi
   - libglm-dev
   - libxi6
   - libgconf-2-4
+  - libxxf86vm-dev
 
 
 ## Installation


### PR DESCRIPTION
This PR adds a list of required Dependancies for Ubuntu/Debain to the README and the command to install all of them, found [here](https://wiki.blender.org/wiki/Building_Blender/Linux/Ubuntu), with the exception of Conda. A link to the Conda homepage is provided.

It also updates the submodules file to have consistant usage of the cloning protocol, each URL has been updated to use HTTPS.