### PR TITLE
replace diameter with radius in butil.spawn_capsule

### DIFF
--- a/infinigen/core/util/blender.py
+++ b/infinigen/core/util/blender.py
@@ -509,7 +509,7 @@ def spawn_capsule(rad, height, us=32, vs=16):
     bpy.context.collection.objects.link(obj)
 
     bm = bmesh.new()
-    bmesh.ops.create_uvsphere(bm, u_segments=us, v_segments=vs, diameter=2 * rad)
+    bmesh.ops.create_uvsphere(bm, u_segments=us, v_segments=vs, radius=rad)
 
     for v in bm.verts:
         if v.co.z > 0:


### PR DESCRIPTION
`bmesh.ops.create_uvsphere` requires radius instead of diameter in blender 3.6