### PR TITLE
Issue 385 - Update scene view in global_flat_shading()

### DIFF
--- a/infinigen/core/rendering/render.py
+++ b/infinigen/core/rendering/render.py
@@ -252,6 +252,7 @@ def global_flat_shading():
                     vol_socket = node.inputs["Volume"]
                     if len(vol_socket.links) > 0:
                         nw.links.remove(vol_socket.links[0])
+    bpy.context.view_layer.update()
 
     for obj in bpy.context.scene.view_layers["ViewLayer"].objects:
         if obj.type != "MESH":

--- a/infinigen/core/rendering/render.py
+++ b/infinigen/core/rendering/render.py
@@ -243,7 +243,7 @@ def global_flat_shading():
     for obj in bpy.context.scene.view_layers["ViewLayer"].objects:
         if "fire_system_type" in obj and obj["fire_system_type"] == "volume":
             continue
-        if obj.name.lower() in {"atmosphere", "atmosphere_fine"}:
+        if obj.name.lower() in {"atmosphere", "atmosphere_fine", "liquid", "liquid_fine"}:
             bpy.data.objects.remove(obj)
         elif obj.active_material is not None:
             nw = obj.active_material.node_tree


### PR DESCRIPTION
blendergt task crashes at globat_flat_shading().  See issue 385

Updating the scene after removing 'Atmosphere' and 'Atmosphere Fine' objects seems to fix it.  Add `bpy.context.view_layer.update()` after removing these objects

Also remove 'liquid' and 'liquid_fine' for global_flat_shading.