### PR TITLE
Typo fix

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -108,7 +108,7 @@ INFINIGEN_INSTALL_CUSTOMGT=True bash scripts/install/interactive_blender.sh
 
 Once complete, you can use the helper script `python -m infinigen.launch_blender` to launch a blender UI, which will find and execute the `blender` executable in your `infinigen/blender` or `infinigen/Blender.app` folder.
 
-:warning: If you installed Infinigen as a Blender-Python scriptand encounter encounter example commands of the form `python -m <MODULEPATH> <ARGUMENTS>` in our documentation, you should instead run `python -m infinigen.launch_blender -m <MODULEPATH> -- <ARGUMENTS>` to launch them using your standalone blender installation rather than the system python..
+:warning: If you installed Infinigen as a Blender-Python script and encounter example commands of the form `python -m <MODULEPATH> <ARGUMENTS>` in our documentation, you should instead run `python -m infinigen.launch_blender -m <MODULEPATH> -- <ARGUMENTS>` to launch them using your standalone blender installation rather than the system python..
 
 ## Using Infinigen in a Docker Container
 


### PR DESCRIPTION
Fixed typo in a warning under "Installing Infinigen as a Blender Python Script"