### PR TITLE
Fix unmatched height of assets and pholders of kitchen_space

### DIFF
--- a/infinigen/assets/objects/shelves/kitchen_space.py
+++ b/infinigen/assets/objects/shelves/kitchen_space.py
@@ -249,6 +249,9 @@ class KitchenSpaceFactory(AssetFactory):
         parts.append(cabinet_bottom)
 
         surface.add_geomod(cabinet_bottom, geometry_nodes_add_cabinet_top, apply=True)
+        # scale to make the heights of pholder and asset matched
+        scale_z = (cabinet_bottom_height+0.13) / cabinet_bottom.dimensions.z
+        cabinet_bottom.dimensions = cabinet_bottom.dimensions * scale_z
 
         if not self.island:
             # top
@@ -298,6 +301,13 @@ class KitchenSpaceFactory(AssetFactory):
             else:
                 raise NotImplementedError
 
+            bpy.ops.object.select_all(action="DESELECT")
+            # offset to make the height of the top mid the same as defined by dimension.z
+            z_offset = z - (top_mid.matrix_world @ Vector(butil.bounds(top_mid)[1])).z
+            cabinet_top_left.location.z = cabinet_top_left.location.z + z_offset
+            cabinet_top_right.location.z = cabinet_top_right.location.z + z_offset
+            top_mid.location.z = top_mid.location.z + z_offset
+
             # parts += [sink, cabinet_top_left, cabinet_top_right, top_mid]
             parts += [cabinet_top_left, cabinet_top_right, top_mid]
 
@@ -305,8 +315,6 @@ class KitchenSpaceFactory(AssetFactory):
             parts
         )  # [cabinet_bottom, sink, cabinet_top_left, cabinet_top_right, top_mid])
 
-        if not self.island:
-            kitchen_space.dimensions = self.dimensions
         butil.apply_transform(kitchen_space)
 
         tagging.tag_system.relabel_obj(kitchen_space)


### PR DESCRIPTION
Related to #376 . Fixes the unmatched heights of the pholders and assets of `KitchenSpaceFactory`, which will make small objects land `cu.on` the surfaces.