### PR TITLE
fix: Add missing cstddef include to FastNoiseLite.h

### DIFF
--- a/infinigen/terrain/source/common/utils/FastNoiseLite.h
+++ b/infinigen/terrain/source/common/utils/FastNoiseLite.h
@@ -52,6 +52,7 @@
 #define FASTNOISELITE_H
 
 #include <cmath>
+#include <cstddef>
 
 
 enum CellularDistanceFunction


### PR DESCRIPTION
Adds missing #include <cstddef> for proper std::size_t declaration. Fixes potential compilation errors on strict C++17/C++20 implementations.