### PR TITLE
fix(util/blender): clear ghost shape keys to fix jellyfish asset gene…

### DIFF
--- a/infinigen/core/util/blender.py
+++ b/infinigen/core/util/blender.py
@@ -787,6 +787,16 @@ def save_blend(path, autopack=False, verbose=False):
     with Suppress():
         if autopack:
             bpy.ops.file.autopack_toggle()
+
+        # Remove orphaned shape keys that cause save crashes
+        for sk in list(bpy.data.shape_keys):
+            # If the shape key has no users, or we want to force cleanup
+            if sk.user == 0:
+                bpy.data.shape_keys.remove(sk)
+                
+        # Run a full orphan purge just to be safe
+        bpy.ops.outliner.orphans_purge(do_local_ids=True, do_linked_ids=True, do_recursive=True)
+        
         bpy.ops.wm.save_as_mainfile(filepath=str(path))
         if autopack:
             bpy.ops.file.autopack_toggle()


### PR DESCRIPTION
…ration. Needs harsh testing to make sure doesn't break something downstream
"6 scatter:jellyfish instances created.
[10:08:54.460] [init] [INFO] | Available devices have types=['OPTIX', 'OPTIX', 'CUDA', 'CUDA', 'CPU']
[10:08:54.460] [init] [INFO] | Cycles will use use_device_type='OPTIX', len(use_devices)=2
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/path/to/infinigen/infinigen_examples/generate_individual_assets.py", line 759, in <module>
    main(args)
  File "/path/to/infinigen/infinigen_examples/generate_individual_assets.py", line 563, in main
    mapfunc(build_and_save_asset, targets, args)
  File "/path/to/anaconda3/envs/infinigen/lib/python3.11/site-packages/gin/config.py", line 1605, in gin_wrapper
    utils.augment_exception_message_and_reraise(e, err_str)
  File "/path/to/anaconda3/envs/infinigen/lib/python3.11/site-packages/gin/utils.py", line 41, in augment_exception_message_and_reraise
    raise proxy.with_traceback(exception.__traceback__) from None
  File "/path/to/anaconda3/envs/infinigen/lib/python3.11/site-packages/gin/config.py", line 1582, in gin_wrapper
    return fn(*new_args, **new_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/infinigen/infinigen_examples/generate_individual_assets.py", line 506, in mapfunc
    return [f(i) for i in its]
           ^^^^^^^^^^^^^^^^^^^
  File "/path/to/infinigen/infinigen_examples/generate_individual_assets.py", line 506, in <listcomp>
    return [f(i) for i in its]
            ^^^^
  File "/path/to/infinigen/infinigen_examples/generate_individual_assets.py", line 388, in build_and_save_asset
    butil.save_blend(output_folder / "scene.blend", autopack=True)
  File "/path/to/infinigen/infinigen/core/util/blender.py", line 790, in save_blend
    bpy.ops.wm.save_as_mainfile(filepath=str(path))
  File "/path/to/anaconda3/envs/infinigen/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/ops.py", line 109, in __call__
    ret = _op_call(self.idname_py(), kw)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Error: Shapekey KEKey.001 has an invalid 'from' pointer ((nil)), it will be deleted
Error: Shapekey KEKey.002 has an invalid 'from' pointer ((nil)), it will be deleted
...
[Additional KEKey errors truncated]
...
  In call to configurable 'mapfunc' (<function mapfunc at 0x7005fd7b2ac0>)"