### PR TITLE
fix: use EXACT solver for cutter booleans to avoid silent infinite hang

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -249,3 +249,4 @@ v1.18.0
 
 v1.19.0
 - Add new articulated object generators and sim features for Infinigen-Articulated
+- Use Boolean modifier EXACT solver in populate.apply_cutter to avoid silent infinite hang on degenerate cutter geometry.

--- a/infinigen/core/constraints/example_solver/populate.py
+++ b/infinigen/core/constraints/example_solver/populate.py
@@ -35,7 +35,7 @@ def apply_cutter(state, objkey, cutter):
             "BOOLEAN",
             object=butil.copy(cutter),
             operation="DIFFERENCE",
-            solver="FAST",
+            solver="EXACT",
         )
 
         target_obj_name = state.objs[relation_state.target_name].obj.name


### PR DESCRIPTION
The Blender Boolean modifier's FAST solver (legacy BMesh CSG) can enter an infinite loop in C++ when given degenerate or near-degenerate geometry. No Python exception is raised; the worker just hangs forever.

We hit this consistently in `apply_cutter` (called per-asset during populate) when a cutter or parent surface has sub-microsquare faces. Multi-floor predefined floor plans where solidified walls have cross-floor intersections at staircase-room boundaries are an easy trigger; in our debugging, an Apollo-cloud Generate stage hung silently for hours during populate before we noticed.

The EXACT solver (Mesh library MOAT) is slower but the slowdown vs FAST is bounded.

Tradeoff: roughly +20% wallclock for typical scenes. Worth it for elimination of an unbounded silent failure mode.