### PR TITLE
Add offroad/: path-first off-road scene generation from OpenDRIVE

### DIFF
--- a/offroad/__init__.py
+++ b/offroad/__init__.py
@@ -1,0 +1,11 @@
+# Off-road scene generation (path-first) built on top of Infinigen.
+#
+# Design principle: the road path is AUTHORITATIVE. Terrain and vegetation are
+# generated to CONFORM to the road ("environment follows road"), not the other
+# way around. Terrain is *anchored* to the road elevation so that no spurious
+# plateaus or canyons appear next to it.
+#
+# This package deliberately does NOT use Infinigen's C/CUDA terrain SDF pipeline
+# (which generates terrain independently of any road). It builds its own
+# road-anchored ground mesh and then uses Infinigen purely as an asset/scatter/
+# material/lighting/render library.

--- a/offroad/biomes.py
+++ b/offroad/biomes.py
@@ -1,0 +1,65 @@
+"""Biome presets: the only environment-specific layer.
+
+The road-conforming core (xodr -> anchored terrain -> dist_to_road -> avoidance
+-> road surface -> camera -> render) is biome-agnostic. A preset only changes:
+  - terrain relief (amplitude / noise),
+  - terrain colour + lighting,
+  - which Infinigen assets get scattered (see vegetation.populate_biome).
+
+Driven by `--biome` or spec.json["biome"].
+"""
+
+from __future__ import annotations
+
+# canonical biome name -> spec.json / scene_type aliases
+ALIASES = {
+    "plain": "grassland",
+    "grass": "grassland",
+    "snowy_mountain": "snow",
+    "snowy": "snow",
+    "arctic": "snow",
+    "snow_mountain": "snow",
+}
+
+BIOME_PRESETS = {
+    "grassland": dict(
+        amplitude=3.2, base_freq=0.012, octaves=6, transition=16.0,
+        terrain_color=(0.20, 0.20, 0.10), sun_energy=3.0, sky_strength=1.0,
+        scatters=["grass", "ground_cover", "pebbles", "trees"],
+        tree_n=12, bush_n=36,
+    ),
+    "desert": dict(
+        amplitude=5.5, base_freq=0.007, octaves=5, transition=20.0,
+        terrain_color=(0.62, 0.48, 0.28), sun_energy=5.5, sky_strength=1.1,
+        scatters=["cactus", "pebbles", "boulders_extra"],  # NO grass
+        cactus_n=16, boulder_n=30, tree_n=0, bush_n=0,
+    ),
+    "mountain": dict(
+        amplitude=20.0, base_freq=0.010, octaves=7, transition=16.0,
+        terrain_color=(0.33, 0.30, 0.27), sun_energy=3.5, sky_strength=1.0,
+        scatters=["pebbles", "boulders_extra", "trees", "grass_sparse"],
+        boulder_n=28, tree_n=14, bush_n=8,
+    ),
+    "snow": dict(
+        amplitude=14.0, base_freq=0.010, octaves=6, transition=16.0,
+        terrain_color=(0.86, 0.88, 0.92), sun_energy=4.0, sky_strength=1.2,
+        # NOTE: snow_layer.apply + bush/tree populate both hang on the large snow
+        # terrain; alpine snowfield = white terrain material + rocks (realistic).
+        scatters=["pebbles", "boulders_extra"],
+        boulder_n=24, tree_n=0, bush_n=0,
+    ),
+    "forest": dict(
+        amplitude=5.0, base_freq=0.012, octaves=6, transition=16.0,
+        terrain_color=(0.12, 0.13, 0.06), sun_energy=2.2, sky_strength=0.8,
+        scatters=["grass", "ground_cover", "fern", "pebbles", "trees_dense"],
+        tree_n=22, bush_n=24,
+    ),
+}
+
+
+def resolve(biome: str | None) -> tuple[str, dict]:
+    name = (biome or "grassland").strip().lower()
+    name = ALIASES.get(name, name)
+    if name not in BIOME_PRESETS:
+        name = "grassland"
+    return name, BIOME_PRESETS[name]

--- a/offroad/build_scene.py
+++ b/offroad/build_scene.py
@@ -1,0 +1,263 @@
+"""End-to-end: xodr -> detailed grassland off-road scene.
+
+    cd <infinigen repo root>
+    ~/anaconda3/envs/infinigen/bin/python -m offroad.build_scene \
+        --xodr /tmp/mcp_grassland4/scenes/offroad_driving/grassland_llm4/scenario.xodr \
+        --out outputs/offroad/grassland.blend --render --trees
+
+Pipeline:
+  1. parse xodr -> RoadSpec (centerline + elevation + width + boulders)   [offroad.road_spec]
+  2. road-anchored terrain heightfield -> mesh + baked dist_to_road       [offroad.conform_terrain / build_terrain]
+  3. init Infinigen gin (base_nature + plain.gin) so asset factories work
+  4. materials (grassland soil base + dirt road ribbon) + sky lighting
+  5. vegetation: grass + pebbles + xodr boulders (+ optional trees/bushes), all off-corridor
+  6. camera along the road; optional EEVEE preview render
+  7. save .blend
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+import bpy
+import numpy as np
+
+logging.basicConfig(level=logging.INFO, format="[%(name)s] %(message)s")
+log = logging.getLogger("offroad.build_scene")
+
+
+def _init_infinigen(seed=77):
+    """We deliberately do NOT call Infinigen's gin pipeline (it pulls in the
+    terrain/OcMesher stack and a scene_type config we don't want). Asset
+    factories are plain gin.configurable functions that fall back to their
+    signature defaults when no bindings are present, which is all we need."""
+    import numpy as _np
+
+    _np.random.seed(seed)
+
+
+def _simple_material(name, rgb, roughness=0.95):
+    mat = bpy.data.materials.new(name)
+    mat.use_nodes = True
+    bsdf = mat.node_tree.nodes.get("Principled BSDF")
+    bsdf.inputs["Base Color"].default_value = (*rgb, 1.0)
+    bsdf.inputs["Roughness"].default_value = roughness
+    return mat
+
+
+def _arclen(centerline):
+    seg = np.linalg.norm(np.diff(centerline[:, :2], axis=0), axis=1)
+    return np.concatenate([[0.0], np.cumsum(seg)])
+
+
+def _point_at_s(centerline, s_query):
+    s = _arclen(centerline)
+    i = int(np.clip(np.searchsorted(s, s_query) - 1, 0, len(s) - 2))
+    seg = s[i + 1] - s[i]
+    u = 0.0 if seg < 1e-9 else (s_query - s[i]) / seg
+    p = centerline[i] * (1 - u) + centerline[i + 1] * u
+    d = centerline[i + 1] - centerline[i]
+    d = d / (np.linalg.norm(d) + 1e-9)
+    return p, d
+
+
+def _look_at(cam, target):
+    import mathutils
+
+    direction = mathutils.Vector(target) - cam.location
+    cam.rotation_euler = direction.to_track_quat("-Z", "Y").to_euler()
+
+
+def _driving_camera(road, station_m, name="cam_driving"):
+    cam_data = bpy.data.cameras.new(name)
+    cam_data.lens = 22.0
+    cam = bpy.data.objects.new(name, cam_data)
+    bpy.context.scene.collection.objects.link(cam)
+    p, d = _point_at_s(road.centerline, station_m)
+    cam.location = mathutils_vec(p + np.array([0, 0, 2.2]) - d * 7.0)
+    look = _point_at_s(road.centerline, min(station_m + 25, _arclen(road.centerline)[-1]))[0]
+    _look_at(cam, (look[0], look[1], look[2] + 1.0))
+    return cam
+
+
+def _overview_camera(road, name="cam_overview"):
+    cam_data = bpy.data.cameras.new(name)
+    cam_data.lens = 28.0
+    cam = bpy.data.objects.new(name, cam_data)
+    bpy.context.scene.collection.objects.link(cam)
+    c = road.centerline
+    cx, cy = c[:, 0].mean(), c[:, 1].mean()
+    span = max(c[:, 0].ptp(), c[:, 1].ptp())
+    cam.location = mathutils_vec((cx - span * 0.2, cy - span * 0.95, c[:, 2].max() + span * 0.5))
+    _look_at(cam, (cx, cy, c[:, 2].mean()))
+    return cam
+
+
+def _detail_camera(road, station_m, name="cam_detail"):
+    """Low, close, oblique shot of the road surface to show ruts/washboard/potholes."""
+    cam_data = bpy.data.cameras.new(name)
+    cam_data.lens = 35.0
+    cam = bpy.data.objects.new(name, cam_data)
+    bpy.context.scene.collection.objects.link(cam)
+    p, d = _point_at_s(road.centerline, station_m)
+    cam.location = mathutils_vec(p + np.array([0, 0, 0.9]) - d * 4.5)
+    look = _point_at_s(road.centerline, station_m + 4.0)[0]
+    _look_at(cam, (look[0], look[1], look[2] + 0.15))
+    return cam
+
+
+def mathutils_vec(arr):
+    import mathutils
+
+    return mathutils.Vector((float(arr[0]), float(arr[1]), float(arr[2])))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--xodr", type=str, required=True)
+    ap.add_argument("--spec", type=str, default=None,
+                    help="spec.json with road.features (default: sibling of xodr)")
+    ap.add_argument("--out", type=Path, default=Path("outputs/offroad/grassland.blend"))
+    ap.add_argument("--biome", type=str, default=None,
+                    help="grassland|desert|mountain|snow|forest (default: spec.json biome)")
+    ap.add_argument("--seed", type=int, default=77)
+    ap.add_argument("--margin", type=float, default=30.0)
+    ap.add_argument("--spacing", type=float, default=0.7)
+    ap.add_argument("--amplitude", type=float, default=None, help="override biome relief")
+    ap.add_argument("--render", action="store_true")
+    ap.add_argument("--raytrace", action="store_true", help="slow raytraced GI/AO")
+    ap.add_argument("--res", type=str, default="960x540")
+    args = ap.parse_args()
+
+    np.random.seed(args.seed)
+
+    import json
+
+    from offroad import biomes
+    from offroad import build_terrain as bt
+    from offroad import road_surface as rs
+    from offroad import vegetation as veg
+    from offroad.conform_terrain import build_heightfield, validate
+    from offroad.road_spec import from_xodr
+
+    # 1) parse xodr + spec (features + biome) -------------------------------
+    road = from_xodr(args.xodr)
+    spec_path = args.spec or str(Path(args.xodr).with_name("spec.json"))
+    features = rs.load_features(spec_path)
+    spec_biome = None
+    try:
+        spec_biome = json.loads(open(spec_path).read()).get("biome")
+    except Exception:  # noqa: BLE001
+        pass
+    biome_name, preset = biomes.resolve(args.biome or spec_biome)
+    if args.amplitude is not None:
+        preset = {**preset, "amplitude": args.amplitude}
+    log.info(f"biome={biome_name}  relief_amp={preset['amplitude']}  "
+             f"scatters={preset['scatters']}  features={[f.get('type') for f in features]}")
+    c = road.centerline
+    log.info(
+        f"road: {len(c)} pts, width {road.width} m, length {_arclen(c)[-1]:.1f} m, "
+        f"z[{c[:,2].min():.2f},{c[:,2].max():.2f}], {len(road.obstacles)} boulders"
+    )
+
+    bt._clear_scene()
+
+    # 2) terrain (relief from biome preset) --------------------------------
+    hf = build_heightfield(
+        road, margin=args.margin, spacing=args.spacing, amplitude=preset["amplitude"],
+        transition=preset["transition"], shoulder=road.width * 0.5 + 1.0, noise_seed=args.seed,
+        noise_kwargs={"octaves": preset["octaves"], "base_freq": preset["base_freq"],
+                      "persistence": 0.5},
+    )
+    v = validate(hf, road)
+    log.info(f"terrain validate: {v}")
+    terrain = bt.ground_to_mesh(hf, road, name="offroad_terrain")
+    road_curve = bt.road_to_curve(road)
+    # detailed dirt road surface with ruts / washboard / potholes / mud
+    road_obj = rs.road_surface_to_mesh(road, features, seed=args.seed)
+
+    # 3) infinigen asset factories (no gin pipeline) ------------------------
+    _init_infinigen(seed=args.seed)
+
+    # 4) materials + lighting ----------------------------------------------
+    terrain.data.materials.clear()
+    terrain.data.materials.append(_simple_material(f"{biome_name}_ground", preset["terrain_color"]))
+    # road surface already carries its own dirt/mud materials (road_surface.py)
+    scn = bpy.context.scene
+    if scn.world is None:
+        scn.world = bpy.data.worlds.new("World")
+    scn.world.use_nodes = True
+    try:
+        from infinigen.assets.lighting import sky_lighting
+
+        sky_lighting.add_lighting()
+        log.info("sky lighting (nishita) added")
+    except Exception as e:  # noqa: BLE001
+        log.warning(f"sky lighting fallback (sun+sky): {e}")
+        scn.world.node_tree.nodes["Background"].inputs[0].default_value = (0.5, 0.7, 0.95, 1)
+        scn.world.node_tree.nodes["Background"].inputs[1].default_value = 1.2
+        scn.world.node_tree.nodes["Background"].inputs[1].default_value = 1.2
+
+    # explicit LOW sun with shadows so road relief (ruts/washboard/potholes)
+    # casts visible shadow bands. Azimuth ~ along the road at the detail feature.
+    feat_s0 = next((float(f["s"]) for f in features
+                    if str(f.get("type", "")).lower() in ("washboard", "pothole")), 30.0)
+    _, tdir = _point_at_s(c, min(feat_s0, _arclen(c)[-1] - 1))
+    sun_az = np.arctan2(tdir[1], tdir[0])
+    sun = bpy.data.objects.new("RakingSun", bpy.data.lights.new("RakingSun", "SUN"))
+    sun.data.energy = preset["sun_energy"]
+    sun.data.angle = np.radians(1.0)  # sharpish shadows
+    sun.data.use_shadow = True
+    sun.rotation_euler = (np.radians(70), 0, sun_az + np.radians(90))  # ~20° above horizon
+    scn.collection.objects.link(sun)
+
+    # 5) vegetation per biome (all off-corridor) ---------------------------
+    buf = road.width * 0.5 + 0.8
+    veg.populate_biome(preset, terrain, road, buffer_m=buf)
+
+    # safety net: never render leftover placeholder cubes
+    for coll in bpy.data.collections:
+        if coll.name.startswith("placeholders:"):
+            coll.hide_render = True
+            coll.hide_viewport = True
+
+    # 6) cameras + optional renders ----------------------------------------
+    total = _arclen(c)[-1]
+    cam_drive = _driving_camera(road, station_m=total * 0.25)
+    cam_over = _overview_camera(road)
+    # focus the detail cam on the first washboard/pothole feature if present
+    feat_s = next((float(f["s"]) for f in features
+                   if str(f.get("type", "")).lower() in ("washboard", "pothole")), total * 0.35)
+    cam_detail = _detail_camera(road, station_m=max(2.0, feat_s - 4.0))
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    if args.render:
+        scn = bpy.context.scene
+        scn.render.engine = "BLENDER_EEVEE_NEXT"
+        w, h = (int(x) for x in args.res.lower().split("x"))
+        scn.render.resolution_x, scn.render.resolution_y = w, h
+        try:  # shadow maps (fast) give relief; raytracing too slow on big terrain
+            scn.eevee.use_raytracing = bool(args.raytrace)
+            scn.eevee.use_shadows = True
+            scn.eevee.taa_render_samples = 24
+        except Exception:  # noqa: BLE001
+            pass
+        for cam, tag in [(cam_over, "overview"), (cam_drive, "driving"), (cam_detail, "detail")]:
+            try:
+                scn.camera = cam
+                png = args.out.with_name(f"{args.out.stem}_{tag}.png")
+                scn.render.filepath = str(png.resolve())
+                bpy.ops.render.render(write_still=True)
+                log.info(f"rendered {tag} -> {png}")
+            except Exception as e:  # noqa: BLE001
+                log.warning(f"render {tag} skipped: {e}")
+        scn.camera = cam_drive
+
+    bpy.ops.wm.save_as_mainfile(filepath=str(args.out.resolve()))
+    log.info(f"saved {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/offroad/build_terrain.py
+++ b/offroad/build_terrain.py
@@ -1,0 +1,171 @@
+"""Build the road-anchored ground as a Blender mesh and save a .blend to inspect.
+
+Run with a Python that has `bpy` available, e.g. the infinigen env:
+
+    ~/anaconda3/envs/infinigen/bin/python -m offroad.build_terrain \
+        --out outputs/offroad/proto.blend
+
+What it produces in the .blend:
+    - `offroad_ground`   : the conformed terrain mesh, with baked POINT attributes
+                           `dist_to_road`, `z_road`, `road_falloff`, and a
+                           `road_viz` color attribute (red carriageway, green sides).
+    - `road_centerline`  : a POLY curve along the path (for camera/ego FOLLOW_PATH).
+    - `road_ribbon`      : a thin flat strip at road elevation, to eyeball the fit.
+
+No Infinigen terrain SDF is used; this is the path-first ground the rest of the
+pipeline will scatter vegetation onto.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import bpy
+import numpy as np
+
+from offroad.conform_terrain import Heightfield, build_heightfield, road_falloff, validate
+from offroad.road_spec import RoadSpec, synthetic_s_curve
+
+
+def _clear_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+
+def _grid_faces(ny: int, nx: int) -> np.ndarray:
+    r = np.arange(ny - 1)
+    c = np.arange(nx - 1)
+    R, C = np.meshgrid(r, c, indexing="ij")
+    v00 = (R * nx + C).ravel()
+    v01 = (R * nx + C + 1).ravel()
+    v11 = ((R + 1) * nx + C + 1).ravel()
+    v10 = ((R + 1) * nx + C).ravel()
+    # CCW from above -> +Z normals
+    return np.stack([v00, v01, v11, v10], axis=1)
+
+
+def ground_to_mesh(hf: Heightfield, road: RoadSpec, name: str = "offroad_ground"):
+    ny, nx = hf.shape
+    verts = np.stack([hf.X.ravel(), hf.Y.ravel(), hf.Z.ravel()], axis=1)
+    faces = _grid_faces(ny, nx)
+
+    mesh = bpy.data.meshes.new(name)
+    mesh.from_pydata(verts.tolist(), [], faces.tolist())
+    mesh.update()
+    obj = bpy.data.objects.new(name, mesh)
+    bpy.context.scene.collection.objects.link(obj)
+
+    # --- baked attributes (POINT domain, vertex order == hf.ravel()) ---
+    dist = hf.dist.ravel()
+    zr = hf.z_road.ravel()
+    fall = road_falloff(hf.dist, road.half_width, transition=14.0, shoulder=1.5).ravel()
+
+    for attr_name, data in [
+        ("dist_to_road", dist),
+        ("z_road", zr),
+        ("road_falloff", fall),
+    ]:
+        a = mesh.attributes.new(attr_name, "FLOAT", "POINT")
+        a.data.foreach_set("value", data.astype(np.float32))
+
+    # --- visualization color: red carriageway, yellow->green by falloff ---
+    on_road = dist <= road.half_width
+    rgba = np.zeros((verts.shape[0], 4), dtype=np.float32)
+    rgba[:, 3] = 1.0
+    # sides: lerp yellow(near, fall=0) -> green(far, fall=1)
+    rgba[:, 0] = (1.0 - fall) * 0.9
+    rgba[:, 1] = 0.55 + 0.35 * fall
+    rgba[:, 2] = 0.10
+    # carriageway: red
+    rgba[on_road] = (0.85, 0.10, 0.10, 1.0)
+    col = mesh.color_attributes.new("road_viz", "FLOAT_COLOR", "POINT")
+    col.data.foreach_set("color", rgba.ravel())
+
+    for p in mesh.polygons:
+        p.use_smooth = True
+    mesh.update()
+    return obj
+
+
+def road_to_curve(road: RoadSpec, name: str = "road_centerline"):
+    cd = bpy.data.curves.new(name, "CURVE")
+    cd.dimensions = "3D"
+    sp = cd.splines.new("POLY")
+    pts = road.centerline
+    sp.points.add(len(pts) - 1)
+    flat = np.concatenate([pts, np.ones((len(pts), 1))], axis=1).astype(np.float32)
+    sp.points.foreach_set("co", flat.ravel())
+    obj = bpy.data.objects.new(name, cd)
+    bpy.context.scene.collection.objects.link(obj)
+    return obj
+
+
+def road_ribbon(road: RoadSpec, name: str = "road_ribbon"):
+    """A thin flat strip at road elevation, offset +0.05 m, to eyeball the fit."""
+    c = road.centerline
+    tang = np.gradient(c[:, :2], axis=0)
+    tang /= np.linalg.norm(tang, axis=1, keepdims=True) + 1e-9
+    normal = np.stack([-tang[:, 1], tang[:, 0]], axis=1)  # left perpendicular
+    hw = road.half_width
+    left = c.copy()
+    right = c.copy()
+    left[:, :2] += normal * hw
+    right[:, :2] -= normal * hw
+    left[:, 2] += 0.05
+    right[:, 2] += 0.05
+    verts = np.concatenate([left, right], axis=0)
+    K = len(c)
+    faces = []
+    for i in range(K - 1):
+        faces.append([i, i + 1, K + i + 1, K + i])
+    mesh = bpy.data.meshes.new(name)
+    mesh.from_pydata(verts.tolist(), [], faces)
+    mesh.update()
+    obj = bpy.data.objects.new(name, mesh)
+    bpy.context.scene.collection.objects.link(obj)
+    return obj
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", type=Path, default=Path("outputs/offroad/proto.blend"))
+    ap.add_argument("--spacing", type=float, default=1.0)
+    ap.add_argument("--amplitude", type=float, default=9.0)
+    ap.add_argument("--margin", type=float, default=55.0)
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args()
+
+    _clear_scene()
+
+    road = synthetic_s_curve()
+    hf = build_heightfield(
+        road,
+        margin=args.margin,
+        spacing=args.spacing,
+        amplitude=args.amplitude,
+        transition=14.0,
+        shoulder=1.5,
+        noise_seed=args.seed,
+    )
+    v = validate(hf, road)
+    print("=== VALIDATION ===")
+    for k, val in v.items():
+        print(f"  {k:28s}: {val}")
+
+    ground_to_mesh(hf, road)
+    road_to_curve(road)
+    road_ribbon(road)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    bpy.ops.wm.save_as_mainfile(filepath=str(args.out.resolve()))
+    print(f"\nSaved {args.out}")
+    print(
+        "Open with:  ~/anaconda3/envs/infinigen/bin/python -m infinigen.launch_blender "
+        f"{args.out}\n"
+        "Tip: set viewport shading to 'Vertex Color' / the 'road_viz' attribute to see "
+        "the red road vs green sides."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/offroad/conform_terrain.py
+++ b/offroad/conform_terrain.py
@@ -1,0 +1,291 @@
+"""Road-anchored ground heightfield (the heart of "environment follows road").
+
+Core formula, evaluated per ground point (x, y):
+
+    H(x, y) = z_road(x, y)  +  noise(x, y) * amplitude * falloff(dist_to_road)
+
+where
+    z_road(x, y)       elevation of the NEAREST point on the road centerline
+                       (the road's own z-profile, extended sideways) -> the anchor
+    dist_to_road       horizontal distance to the centerline
+    falloff(d)         0 on the carriageway, smoothly ramps to 1 past a
+                       transition band, so natural undulation only "grows" away
+                       from the road.
+
+Consequences:
+    - On the road (d <= half_width): falloff = 0  => H == z_road exactly.
+      The road sits perfectly on the ground, no floating, no vertical wall.
+    - Far from the road: falloff = 1 => full procedural terrain on top of the
+      road-elevation base.
+    - In between: a smooth, bounded-slope embankment / cutting.
+
+Everything here is pure NumPy and importable without Blender, so the "no wall"
+property can be validated headless. The Blender mesh construction lives in
+`build_terrain.py`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from offroad.road_spec import RoadSpec
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic fractal value noise (no external deps)
+# --------------------------------------------------------------------------- #
+def _hash01(ix: np.ndarray, iy: np.ndarray, seed: int) -> np.ndarray:
+    """Vectorized integer hash -> float in [0, 1) for lattice corners."""
+    ix = ix.astype(np.int64)
+    iy = iy.astype(np.int64)
+    h = (ix * np.int64(374761393) + iy * np.int64(668265263)) ^ np.int64(seed)
+    h = (h ^ (h >> np.int64(13))) * np.int64(1274126177)
+    h = h ^ (h >> np.int64(16))
+    return (h & np.int64(0xFFFFFFFF)).astype(np.float64) / 4294967296.0
+
+
+def _smoothstep(t: np.ndarray) -> np.ndarray:
+    return t * t * (3.0 - 2.0 * t)
+
+
+def _value_noise_2d(x: np.ndarray, y: np.ndarray, seed: int, freq: float) -> np.ndarray:
+    xf = x * freq
+    yf = y * freq
+    x0 = np.floor(xf)
+    y0 = np.floor(yf)
+    tx = _smoothstep(xf - x0)
+    ty = _smoothstep(yf - y0)
+    x0i, y0i = x0.astype(np.int64), y0.astype(np.int64)
+    v00 = _hash01(x0i, y0i, seed)
+    v10 = _hash01(x0i + 1, y0i, seed)
+    v01 = _hash01(x0i, y0i + 1, seed)
+    v11 = _hash01(x0i + 1, y0i + 1, seed)
+    a = v00 * (1 - tx) + v10 * tx
+    b = v01 * (1 - tx) + v11 * tx
+    return (a * (1 - ty) + b * ty) * 2.0 - 1.0  # -> [-1, 1]
+
+
+def fractal_noise(
+    x: np.ndarray,
+    y: np.ndarray,
+    seed: int = 0,
+    octaves: int = 5,
+    base_freq: float = 0.012,
+    lacunarity: float = 2.0,
+    persistence: float = 0.5,
+) -> np.ndarray:
+    """Sum of value-noise octaves, normalized to roughly [-1, 1]."""
+    total = np.zeros_like(x, dtype=np.float64)
+    amp = 1.0
+    freq = base_freq
+    norm = 0.0
+    for o in range(octaves):
+        total += amp * _value_noise_2d(x, y, seed + o * 1013, freq)
+        norm += amp
+        amp *= persistence
+        freq *= lacunarity
+    return total / max(norm, 1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# Distance + elevation to the road centerline
+# --------------------------------------------------------------------------- #
+def nearest_road(
+    qx: np.ndarray, qy: np.ndarray, centerline: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """For each query point, horizontal distance to the centerline polyline and
+    the (interpolated) road elevation at the nearest projection.
+
+    qx, qy : (P,) arrays. centerline : (K, 3). Returns (dist (P,), z_road (P,)).
+    Vectorized over points, loops over the K-1 segments (K is small).
+    """
+    P = qx.shape[0]
+    best_d2 = np.full(P, np.inf)
+    best_z = np.zeros(P)
+    A = centerline[:-1]
+    B = centerline[1:]
+    for a, b in zip(A, B):
+        abx, aby = b[0] - a[0], b[1] - a[1]
+        ab2 = abx * abx + aby * aby
+        if ab2 < 1e-12:
+            continue
+        apx = qx - a[0]
+        apy = qy - a[1]
+        t = (apx * abx + apy * aby) / ab2
+        t = np.clip(t, 0.0, 1.0)
+        projx = a[0] + t * abx
+        projy = a[1] + t * aby
+        dx = qx - projx
+        dy = qy - projy
+        d2 = dx * dx + dy * dy
+        upd = d2 < best_d2
+        best_d2 = np.where(upd, d2, best_d2)
+        z_proj = a[2] + t * (b[2] - a[2])
+        best_z = np.where(upd, z_proj, best_z)
+    return np.sqrt(best_d2), best_z
+
+
+def nearest_road_smooth(
+    qx: np.ndarray, qy: np.ndarray, centerline: np.ndarray, smoothing: float = 3.0
+) -> tuple[np.ndarray, np.ndarray]:
+    """Like `nearest_road`, but the returned elevation is an inverse-distance
+    weighted blend over ALL segments (weight 1/(d^2 + smoothing^2)) instead of a
+    hard nearest pick. This removes the elevation "seam" that a winding road
+    creates where the nearest segment switches between two passes at different
+    heights. `dist` is still the true minimum distance.
+    """
+    P = qx.shape[0]
+    best_d2 = np.full(P, np.inf)
+    sum_w = np.zeros(P)
+    sum_wz = np.zeros(P)
+    s2 = smoothing * smoothing
+    A, B = centerline[:-1], centerline[1:]
+    for a, b in zip(A, B):
+        abx, aby = b[0] - a[0], b[1] - a[1]
+        ab2 = abx * abx + aby * aby
+        if ab2 < 1e-12:
+            continue
+        t = np.clip(((qx - a[0]) * abx + (qy - a[1]) * aby) / ab2, 0.0, 1.0)
+        projx = a[0] + t * abx
+        projy = a[1] + t * aby
+        d2 = (qx - projx) ** 2 + (qy - projy) ** 2
+        z_proj = a[2] + t * (b[2] - a[2])
+        w = 1.0 / (d2 + s2)
+        sum_w += w
+        sum_wz += w * z_proj
+        best_d2 = np.minimum(best_d2, d2)
+    z = sum_wz / np.maximum(sum_w, 1e-12)
+    return np.sqrt(best_d2), z
+
+
+def road_falloff(
+    dist: np.ndarray, half_width: float, transition: float, shoulder: float = 0.0
+) -> np.ndarray:
+    """0 on the carriageway (+optional flat shoulder), smoothstep to 1 over
+    `transition` meters past the shoulder edge."""
+    flat = half_width + shoulder
+    t = (dist - flat) / max(transition, 1e-6)
+    t = np.clip(t, 0.0, 1.0)
+    return _smoothstep(t)
+
+
+# --------------------------------------------------------------------------- #
+# Heightfield assembly
+# --------------------------------------------------------------------------- #
+@dataclass
+class Heightfield:
+    X: np.ndarray  # (ny, nx) meshgrid X
+    Y: np.ndarray  # (ny, nx) meshgrid Y
+    Z: np.ndarray  # (ny, nx) ground height
+    dist: np.ndarray  # (ny, nx) distance to road
+    z_road: np.ndarray  # (ny, nx) nearest road elevation (the anchor)
+    spacing: float
+
+    @property
+    def shape(self):
+        return self.X.shape
+
+
+def build_heightfield(
+    road: RoadSpec,
+    margin: float = 60.0,
+    spacing: float = 1.0,
+    amplitude: float = 9.0,
+    transition: float = 14.0,
+    shoulder: float = 1.5,
+    noise_seed: int = 0,
+    noise_kwargs: dict | None = None,
+    elev_smoothing: float = 4.0,
+) -> Heightfield:
+    """Build the road-anchored ground heightfield over the road's bounding box.
+
+    `elev_smoothing` > 0 uses a distance-weighted elevation anchor (removes the
+    seam where a winding road's nearest segment switches between passes at
+    different heights). 0 falls back to hard nearest-segment elevation.
+    """
+    road = road.resampled(spacing=min(spacing, 1.0))
+    x0, y0, x1, y1 = road.xy_bounds(margin)
+    nx = int(np.ceil((x1 - x0) / spacing)) + 1
+    ny = int(np.ceil((y1 - y0) / spacing)) + 1
+    xs = x0 + np.arange(nx) * spacing
+    ys = y0 + np.arange(ny) * spacing
+    X, Y = np.meshgrid(xs, ys)  # (ny, nx)
+
+    if elev_smoothing > 0:
+        dist, z_road = nearest_road_smooth(
+            X.ravel(), Y.ravel(), road.centerline, smoothing=elev_smoothing
+        )
+    else:
+        dist, z_road = nearest_road(X.ravel(), Y.ravel(), road.centerline)
+    dist = dist.reshape(X.shape)
+    z_road = z_road.reshape(X.shape)
+
+    noise = fractal_noise(X, Y, seed=noise_seed, **(noise_kwargs or {}))
+    fall = road_falloff(dist, road.half_width, transition, shoulder)
+
+    Z = z_road + noise * amplitude * fall
+    return Heightfield(X=X, Y=Y, Z=Z, dist=dist, z_road=z_road, spacing=spacing)
+
+
+# --------------------------------------------------------------------------- #
+# Headless validation: prove there is no "wall"
+# --------------------------------------------------------------------------- #
+def validate(hf: Heightfield, road: RoadSpec) -> dict:
+    """Numeric checks that the road conforms with no vertical wall."""
+    on_road = hf.dist <= road.half_width
+    # 1) On the carriageway, ground must equal road elevation (the anchor).
+    road_err = float(np.abs(hf.Z[on_road] - hf.z_road[on_road]).max()) if on_road.any() else 0.0
+
+    # 2) Max local slope (a wall would be near-vertical, i.e. huge slope).
+    gx = np.gradient(hf.Z, hf.spacing, axis=1)
+    gy = np.gradient(hf.Z, hf.spacing, axis=0)
+    slope = np.sqrt(gx**2 + gy**2)  # rise per meter
+    max_slope = float(slope.max())
+    max_slope_deg = float(np.degrees(np.arctan(max_slope)))
+
+    # 3) Slope specifically in the transition band (the at-risk zone).
+    band = (hf.dist > road.half_width) & (hf.dist <= road.half_width + 16.0)
+    band_slope_deg = (
+        float(np.degrees(np.arctan(slope[band].max()))) if band.any() else 0.0
+    )
+    return {
+        "grid": hf.shape,
+        "road_conform_err_m": road_err,  # want ~0
+        "max_slope_deg": max_slope_deg,  # want < ~80 (no vertical wall)
+        "transition_max_slope_deg": band_slope_deg,
+        "z_range_m": (float(hf.Z.min()), float(hf.Z.max())),
+    }
+
+
+def ascii_cross_section(hf: Heightfield, road: RoadSpec, width: int = 70) -> str:
+    """A perpendicular cross-section through the middle of the path, as ASCII,
+    so you can 'see' that the road is flat and the sides rise smoothly."""
+    ny, nx = hf.shape
+    row = ny // 2
+    z = hf.Z[row]
+    d = hf.dist[row]
+    on = d <= road.half_width
+    zmin, zmax = z.min(), z.max()
+    span = max(zmax - zmin, 1e-6)
+    height = 16
+    # downsample columns to `width`
+    idx = np.linspace(0, nx - 1, width).astype(int)
+    cols = []
+    for i in idx:
+        h = int(round((z[i] - zmin) / span * (height - 1)))
+        cols.append((h, on[i]))
+    lines = []
+    for lv in range(height - 1, -1, -1):
+        line = []
+        for h, ison in cols:
+            if h == lv:
+                line.append("#" if ison else "*")
+            elif h > lv:
+                line.append("#" if ison else ".")
+            else:
+                line.append(" ")
+        lines.append("".join(line))
+    legend = f"  (# = road/below-road, * = ground surface; z {zmin:.1f}..{zmax:.1f} m)"
+    return "\n".join(lines) + "\n" + legend

--- a/offroad/preview.py
+++ b/offroad/preview.py
@@ -1,0 +1,78 @@
+"""Headless preview (no Blender): top-down height map + perpendicular cross
+sections, to visually confirm the road conforms with no wall.
+
+    python -m offroad.preview --out outputs/offroad/preview.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from offroad.conform_terrain import build_heightfield, nearest_road
+from offroad.road_spec import synthetic_s_curve
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", type=Path, default=Path("outputs/offroad/preview.png"))
+    ap.add_argument("--amplitude", type=float, default=9.0)
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args()
+
+    road = synthetic_s_curve()
+    hf = build_heightfield(
+        road, margin=55, spacing=1.0, amplitude=args.amplitude,
+        transition=14.0, shoulder=1.5, noise_seed=args.seed,
+    )
+    c = road.centerline
+
+    fig = plt.figure(figsize=(13, 6))
+
+    # (a) top-down height map + road centerline
+    ax = fig.add_subplot(1, 2, 1)
+    extent = [hf.X.min(), hf.X.max(), hf.Y.min(), hf.Y.max()]
+    im = ax.imshow(hf.Z, origin="lower", extent=extent, cmap="terrain", aspect="equal")
+    ax.plot(c[:, 0], c[:, 1], "r-", lw=2, label="road centerline")
+    # mark the cross-section locations
+    xs_marks = np.linspace(c[:, 0].min() + 10, c[:, 0].max() - 10, 3)
+    for xm in xs_marks:
+        ax.axvline(xm, color="k", ls="--", lw=0.8, alpha=0.6)
+    ax.set_title("Top-down ground height (terrain cmap) + road")
+    ax.set_xlabel("x [m]"); ax.set_ylabel("y [m]")
+    ax.legend(loc="upper right", fontsize=8)
+    fig.colorbar(im, ax=ax, shrink=0.8, label="height z [m]")
+
+    # (b) perpendicular cross sections at three x positions
+    ax2 = fig.add_subplot(1, 2, 2)
+    nx = hf.shape[1]
+    xs = hf.X[0]
+    for xm in xs_marks:
+        col = int(np.argmin(np.abs(xs - xm)))
+        y = hf.Y[:, col]
+        z = hf.Z[:, col]
+        d, zr = nearest_road(hf.X[:, col], y, c)
+        ax2.plot(y, z, lw=1.5, label=f"x={xm:.0f} m")
+        on = d <= road.half_width
+        if on.any():
+            ax2.plot(y[on], z[on], "r.", ms=4)
+    ax2.set_title("Perpendicular cross-sections\n(red dots = carriageway, flat & on-grade)")
+    ax2.set_xlabel("y [m]"); ax2.set_ylabel("height z [m]")
+    ax2.grid(True, alpha=0.3)
+    ax2.legend(fontsize=8)
+    ax2.set_aspect("equal", adjustable="datalim")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(args.out, dpi=110)
+    print(f"Saved {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/offroad/road_spec.py
+++ b/offroad/road_spec.py
@@ -1,0 +1,184 @@
+"""Road path specification (the authoritative input).
+
+A `RoadSpec` is just a 3D centerline polyline (x, y, z in meters) plus a road
+width. For now we provide a hand-made synthetic example so we can validate the
+terrain-conforming math before wiring up a real OpenDRIVE (.xodr) parser.
+
+`from_xodr` is a stub for the next step.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+@dataclass
+class RoadSpec:
+    # centerline: (K, 3) array of [x, y, z] points in meters, ordered along the road
+    centerline: np.ndarray
+    width: float = 6.0  # full carriageway width in meters
+    # optional point obstacles parsed from the source (e.g. xodr <objects>):
+    # list of dicts with keys: id, x, y, z, radius, height, kind
+    obstacles: list = field(default_factory=list)
+
+    def __post_init__(self):
+        self.centerline = np.asarray(self.centerline, dtype=np.float64)
+        assert self.centerline.ndim == 2 and self.centerline.shape[1] == 3, (
+            f"centerline must be (K,3), got {self.centerline.shape}"
+        )
+
+    @property
+    def half_width(self) -> float:
+        return self.width / 2.0
+
+    def xy_bounds(self, margin: float) -> tuple[float, float, float, float]:
+        xy = self.centerline[:, :2]
+        lo = xy.min(axis=0) - margin
+        hi = xy.max(axis=0) + margin
+        return float(lo[0]), float(lo[1]), float(hi[0]), float(hi[1])
+
+    def resampled(self, spacing: float = 1.0) -> "RoadSpec":
+        """Return a copy with the centerline resampled to ~`spacing` meters.
+
+        Dense, evenly spaced points make the point-to-polyline distance accurate.
+        """
+        c = self.centerline
+        seg = np.linalg.norm(np.diff(c[:, :2], axis=0), axis=1)
+        s = np.concatenate([[0.0], np.cumsum(seg)])  # arclength (xy)
+        total = s[-1]
+        n = max(2, int(np.ceil(total / spacing)) + 1)
+        s_new = np.linspace(0.0, total, n)
+        out = np.empty((n, 3), dtype=np.float64)
+        for d in range(3):
+            out[:, d] = np.interp(s_new, s, c[:, d])
+        return RoadSpec(out, self.width)
+
+
+def synthetic_s_curve(
+    length: float = 160.0,
+    amp: float = 28.0,
+    grade: float = 0.04,
+    hill_height: float = 6.0,
+    width: float = 6.0,
+) -> RoadSpec:
+    """A deliberately stressful test path:
+
+    - S-shaped in the XY plane (left/right curves),
+    - a constant uphill `grade` (rise/run), PLUS
+    - a smooth hill bump in the middle of the run.
+
+    The vertical variation is exactly what would create plateaus/canyons under a
+    naive flatten, so it is a good test of the road-anchored approach.
+    """
+    n = 400
+    s = np.linspace(0.0, length, n)
+    x = s
+    y = amp * np.sin(2 * np.pi * s / length)  # one full S
+    z = (
+        grade * s  # steady climb
+        + hill_height * np.exp(-(((s - length * 0.5) / (length * 0.12)) ** 2))  # hill
+    )
+    centerline = np.stack([x, y, z], axis=1)
+    return RoadSpec(centerline, width=width)
+
+
+def _eval_poly(records: list[tuple[float, float, float, float, float]], s: float) -> float:
+    """Evaluate an OpenDRIVE cubic record list [(s0,a,b,c,d), ...] at arclength s.
+    z(s) = a + b*ds + c*ds^2 + d*ds^3, ds = s - s0, using the record with the
+    largest s0 <= s."""
+    if not records:
+        return 0.0
+    rec = records[0]
+    for r in records:
+        if r[0] <= s + 1e-9:
+            rec = r
+        else:
+            break
+    s0, a, b, c, d = rec
+    ds = s - s0
+    return a + b * ds + c * ds * ds + d * ds * ds * ds
+
+
+def from_xodr(path: str, lateral_sign: float = +1.0) -> RoadSpec:
+    """Parse a (line-segment planView) OpenDRIVE file into a RoadSpec.
+
+    Handles the dialect emitted by the offroad toolchain: planView is a dense
+    list of <geometry><line/> segments; elevationProfile is a list of cubic
+    <elevation> records; lane widths give the carriageway width; <objects> give
+    point obstacles (boulders) by (s, t).
+
+    `lateral_sign` flips the sign convention for the lateral `t` offset if the
+    obstacles end up on the wrong side (OpenDRIVE t>0 is left of travel).
+    """
+    root = ET.parse(path).getroot()
+    road = root.find("road")
+    if road is None:
+        raise ValueError(f"{path}: no <road> element")
+
+    # --- planView -> centerline XY (collect each geometry start, then final end)
+    geoms = road.findall("./planView/geometry")
+    if not geoms:
+        raise ValueError(f"{path}: empty planView")
+    s_list, xy = [], []
+    for g in geoms:
+        s_list.append(float(g.get("s")))
+        xy.append((float(g.get("x")), float(g.get("y"))))
+    # append the terminal point of the last segment
+    last = geoms[-1]
+    hdg = float(last.get("hdg"))
+    length = float(last.get("length"))
+    s_list.append(float(last.get("s")) + length)
+    xy.append((xy[-1][0] + length * np.cos(hdg), xy[-1][1] + length * np.sin(hdg)))
+    xy = np.asarray(xy, dtype=np.float64)
+    s_arr = np.asarray(s_list, dtype=np.float64)
+
+    # --- elevationProfile -> z(s)
+    elev_records = []
+    for e in road.findall("./elevationProfile/elevation"):
+        elev_records.append(
+            (float(e.get("s")), float(e.get("a")), float(e.get("b")),
+             float(e.get("c")), float(e.get("d")))
+        )
+    elev_records.sort(key=lambda r: r[0])
+    z = np.array([_eval_poly(elev_records, s) for s in s_arr])
+
+    centerline = np.stack([xy[:, 0], xy[:, 1], z], axis=1)
+
+    # --- lane widths -> carriageway width (sum of |a| over driving lanes)
+    width = 0.0
+    for w in road.findall(".//laneSection/*/lane/width"):
+        width += abs(float(w.get("a", 0.0)))
+    if width <= 0.0:
+        width = 6.0
+
+    spec = RoadSpec(centerline, width=width)
+
+    # --- objects -> obstacles in world coords (s,t) -> (x,y,z)
+    def _frame_at(s_query: float):
+        i = int(np.clip(np.searchsorted(s_arr, s_query) - 1, 0, len(s_arr) - 2))
+        seg = s_arr[i + 1] - s_arr[i]
+        u = 0.0 if seg < 1e-9 else (s_query - s_arr[i]) / seg
+        p = centerline[i] * (1 - u) + centerline[i + 1] * u
+        d = centerline[i + 1][:2] - centerline[i][:2]
+        d = d / (np.linalg.norm(d) + 1e-9)
+        left = np.array([-d[1], d[0]])  # left-normal in XY
+        return p, left
+
+    for obj in road.findall("./objects/object"):
+        s_q = float(obj.get("s", 0.0))
+        t = float(obj.get("t", 0.0)) * lateral_sign
+        p, left = _frame_at(s_q)
+        wx = p[0] + left[0] * t
+        wy = p[1] + left[1] * t
+        spec.obstacles.append({
+            "id": obj.get("id", obj.get("name", "obj")),
+            "kind": obj.get("type", "obstacle"),
+            "x": float(wx), "y": float(wy), "z": float(p[2]),
+            "radius": float(obj.get("radius", 0.4)),
+            "height": float(obj.get("height", 0.6)),
+        })
+
+    return spec

--- a/offroad/road_surface.py
+++ b/offroad/road_surface.py
@@ -1,0 +1,190 @@
+"""Detailed dirt-road surface: a high-resolution (s, t)-parameterized ribbon with
+wheel ruts, washboard ripples, potholes and mud patches displaced into it, plus
+per-face dirt/mud material assignment.
+
+`features` is the list from spec.json["road"]["features"], e.g.
+  {"type":"washboard","s":25,"length_m":8,"amplitude_m":0.08,"wavelength_m":0.5}
+  {"type":"pothole","s":50,"lateral_m":0.5,"radius_m":0.6,"depth_m":0.15}
+  {"type":"mud_patch","s":80,"lateral_m":-0.5,"radius_m":1.5,"depth_m":0.05}
+
+Pure-numpy geometry (testable headless); `road_surface_to_mesh` needs bpy.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import numpy as np
+
+logger = logging.getLogger("offroad.road_surface")
+
+
+def load_features(spec_path: str) -> list[dict]:
+    try:
+        spec = json.loads(open(spec_path).read())
+        return list(spec.get("road", {}).get("features", []))
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"could not read features from {spec_path}: {e}")
+        return []
+
+
+def _resample_by_arclen(centerline: np.ndarray, ds: float):
+    seg = np.linalg.norm(np.diff(centerline[:, :2], axis=0), axis=1)
+    s = np.concatenate([[0.0], np.cumsum(seg)])
+    total = s[-1]
+    n = max(2, int(total / ds) + 1)
+    s_new = np.linspace(0.0, total, n)
+    out = np.empty((n, 3))
+    for d in range(3):
+        out[:, d] = np.interp(s_new, s, centerline[:, d])
+    return s_new, out
+
+
+def build_surface_grid(
+    road,
+    features: list[dict],
+    width: float | None = None,
+    ds: float = 0.08,
+    dt: float = 0.18,
+    lift: float = 0.04,
+    rut_offset_frac: float = 0.42,  # wheel track as fraction of half-width
+    rut_depth: float = 0.05,
+    rut_width: float = 0.22,
+    micro_amp: float = 0.015,
+    seed: int = 0,
+):
+    """Return (s_arr, ts, P (NS,NT,3), mud_mask (NS,NT)). z already displaced."""
+    width = width or road.width
+    hw = width / 2.0
+    s_arr, c = _resample_by_arclen(road.centerline, ds)
+
+    d = np.gradient(c[:, :2], axis=0)
+    d /= np.linalg.norm(d, axis=1, keepdims=True) + 1e-9
+    left = np.stack([-d[:, 1], d[:, 0]], axis=1)  # (NS,2) left normal in XY
+
+    ts = np.arange(-hw, hw + 1e-6, dt)
+    NS, NT = len(s_arr), len(ts)
+
+    P = np.empty((NS, NT, 3))
+    P[:, :, 0] = c[:, 0:1] + np.outer(left[:, 0], ts)
+    P[:, :, 1] = c[:, 1:2] + np.outer(left[:, 1], ts)
+    P[:, :, 2] = c[:, 2:3]
+
+    disp = np.zeros((NS, NT))
+    mud = np.zeros((NS, NT), dtype=bool)
+
+    # --- continuous wheel ruts (two longitudinal grooves) ---
+    rut_t = rut_offset_frac * hw
+    for sign in (-1.0, 1.0):
+        disp -= rut_depth * np.exp(-((ts[None, :] - sign * rut_t) ** 2) / (2 * rut_width**2))
+
+    # --- micro surface roughness (fine dirt bumps) ---
+    rng = np.random.default_rng(seed)
+    micro = (
+        np.sin(s_arr[:, None] * 2.3 + ts[None, :] * 5.1 + rng.uniform(0, 6))
+        + 0.6 * np.sin(s_arr[:, None] * 7.7 - ts[None, :] * 3.3 + rng.uniform(0, 6))
+    )
+    disp += micro_amp * micro
+
+    # --- spec features ---
+    edge = max(1e-3, 0.0)
+    for f in features:
+        typ = str(f.get("type", "")).lower()
+        s0 = float(f.get("s", 0.0))
+        if typ == "washboard":
+            L = float(f.get("length_m", 6.0))
+            amp = float(f.get("amplitude_m", 0.06))
+            wl = max(0.1, float(f.get("wavelength_m", 0.5)))
+            band = (s_arr >= s0) & (s_arr <= s0 + L)
+            taper = np.clip(np.minimum(s_arr - s0, s0 + L - s_arr) / (L * 0.2 + 1e-6), 0, 1)
+            ripple = amp * np.sin(2 * np.pi * (s_arr - s0) / wl) * taper * band
+            disp += ripple[:, None]
+        elif typ in ("pothole", "mud_patch"):
+            tp = float(f.get("lateral_m", 0.0))
+            r = max(0.15, float(f.get("radius_m", 0.5)))
+            depth = float(f.get("depth_m", 0.12))
+            sd = s_arr[:, None] - s0
+            td = ts[None, :] - tp
+            d2 = sd**2 + td**2
+            disp -= depth * np.exp(-d2 / (2 * (r * 0.6) ** 2))
+            if typ == "mud_patch":
+                mud |= d2 < (r * r)
+
+    P[:, :, 2] += disp + lift
+    logger.info(
+        f"road surface grid {NS}x{NT}, ruts@±{rut_t:.2f}m, "
+        f"{sum(1 for f in features if str(f.get('type','')).lower()=='washboard')} washboard, "
+        f"{sum(1 for f in features if str(f.get('type','')).lower()=='pothole')} potholes, "
+        f"{int(mud.any())} mud regions"
+    )
+    return s_arr, ts, P, mud
+
+
+# --------------------------------------------------------------------------- #
+# bpy mesh + materials
+# --------------------------------------------------------------------------- #
+def _dirt_material():
+    import bpy
+
+    mat = bpy.data.materials.new("road_dirt")
+    mat.use_nodes = True
+    nt = mat.node_tree
+    bsdf = nt.nodes.get("Principled BSDF")
+    # subtle noise-driven color variation
+    tex = nt.nodes.new("ShaderNodeTexNoise")
+    tex.inputs["Scale"].default_value = 12.0
+    ramp = nt.nodes.new("ShaderNodeValToRGB")
+    ramp.color_ramp.elements[0].color = (0.22, 0.16, 0.11, 1)
+    ramp.color_ramp.elements[1].color = (0.40, 0.31, 0.22, 1)
+    nt.links.new(tex.outputs["Fac"], ramp.inputs["Fac"])
+    nt.links.new(ramp.outputs["Color"], bsdf.inputs["Base Color"])
+    bsdf.inputs["Roughness"].default_value = 1.0
+    return mat
+
+
+def _mud_material():
+    import bpy
+
+    mat = bpy.data.materials.new("road_mud")
+    mat.use_nodes = True
+    bsdf = mat.node_tree.nodes.get("Principled BSDF")
+    bsdf.inputs["Base Color"].default_value = (0.10, 0.07, 0.05, 1)
+    bsdf.inputs["Roughness"].default_value = 0.25  # wet sheen
+    if "Specular IOR Level" in bsdf.inputs:
+        bsdf.inputs["Specular IOR Level"].default_value = 0.7
+    return mat
+
+
+def road_surface_to_mesh(road, features, seed=0, name="offroad_road", **kw):
+    import bpy
+
+    s_arr, ts, P, mud = build_surface_grid(road, features, seed=seed, **kw)
+    NS, NT = P.shape[:2]
+    verts = P.reshape(-1, 3)
+
+    faces, face_is_mud = [], []
+    for i in range(NS - 1):
+        for j in range(NT - 1):
+            v00 = i * NT + j
+            v01 = i * NT + j + 1
+            v11 = (i + 1) * NT + j + 1
+            v10 = (i + 1) * NT + j
+            faces.append((v00, v01, v11, v10))
+            face_is_mud.append(mud[i, j] or mud[i, j + 1] or mud[i + 1, j] or mud[i + 1, j + 1])
+
+    mesh = bpy.data.meshes.new(name)
+    mesh.from_pydata(verts.tolist(), [], faces)
+    mesh.update()
+    obj = bpy.data.objects.new(name, mesh)
+    bpy.context.scene.collection.objects.link(obj)
+
+    dirt = _dirt_material()
+    mud_mat = _mud_material()
+    mesh.materials.append(dirt)
+    mesh.materials.append(mud_mat)
+    for p, is_mud in zip(mesh.polygons, face_is_mud):
+        p.material_index = 1 if is_mud else 0
+        p.use_smooth = True
+    mesh.update()
+    return obj

--- a/offroad/vegetation.py
+++ b/offroad/vegetation.py
@@ -1,0 +1,234 @@
+"""Vegetation / detail pass for the off-road grassland scene.
+
+Scatters Infinigen assets (grass, rocks, optional trees/bushes) onto the
+road-anchored terrain mesh, keeping everything OFF the road corridor by reading
+the baked `dist_to_road` POINT attribute (same mechanism Infinigen uses for its
+`MaskTag`). Also places the exact xodr boulders.
+
+Requires the infinigen env (bpy + infinigen importable) and gin already inited
+by the caller (see build_scene.py).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import bpy
+import numpy as np
+from numpy.random import uniform as U
+
+from infinigen.core import surface
+from infinigen.core.nodes.node_wrangler import Nodes
+from infinigen.core.util import blender as butil
+
+logger = logging.getLogger("offroad.vegetation")
+
+
+# --------------------------------------------------------------------------- #
+# Off-corridor selection: reads baked `dist_to_road`, 0 on road -> 1 past buffer
+# --------------------------------------------------------------------------- #
+def offroad_selection(buffer_m: float = 2.0, blend_m: float = 2.5, attr="dist_to_road"):
+    def sel(nw):
+        dist = surface.eval_argument(nw, attr)
+        mr = nw.new_node(
+            Nodes.MapRange,
+            input_kwargs={"Value": dist, 1: buffer_m, 2: buffer_m + blend_m},
+            attrs={"interpolation_type": "SMOOTHSTEP"},
+        )
+        return mr
+
+    return sel
+
+
+def offroad_noise_selection(buffer_m=2.0, blend_m=2.5, noise_scale=0.06, thresh=0.45):
+    """Off-corridor mask AND a noise patchiness (for clumpy scatters like rocks)."""
+    base = offroad_selection(buffer_m, blend_m)
+
+    def sel(nw):
+        off = base(nw)
+        noise = nw.new_node(Nodes.NoiseTexture, input_kwargs={"Scale": noise_scale})
+        gt = nw.new_node(
+            Nodes.Math,
+            input_args=[noise.outputs["Fac"], thresh],
+            attrs={"operation": "GREATER_THAN"},
+        )
+        return nw.scalar_multiply(off, gt)
+
+    return sel
+
+
+# --------------------------------------------------------------------------- #
+# Grass
+# --------------------------------------------------------------------------- #
+def apply_grass(terrain, buffer_m=2.2, vol_density=2.5):
+    """Grass scatter with controllable density (Infinigen's grass.Grass hardcodes
+    vol_density up to 5 -> ~1.6M instances, which is far too heavy for large /
+    sparse biomes). We replicate it with an explicit density."""
+    import numpy as np
+    from numpy.random import uniform as U
+
+    from infinigen.assets.objects.grassland.grass_tuft import GrassTuftFactory
+    from infinigen.assets.scatters.utils.wind import wind
+    from infinigen.core.placement.factory import make_asset_collection
+    from infinigen.core.placement.instance_scatter import scatter_instances
+
+    logger.info(f"scattering grass (off-corridor, vol_density={vol_density})...")
+    facs = [GrassTuftFactory(np.random.randint(1e7))]
+    col = make_asset_collection(facs, n=10)
+    scatter_obj = scatter_instances(
+        base_obj=terrain, collection=col, scale=U(1, 3), scale_rand=U(0.7, 1),
+        scale_rand_axi=0.1, vol_density=vol_density, ground_offset=0,
+        normal_fac=U(0, 0.5), rotation_offset=wind(strength=10),
+        selection=offroad_selection(buffer_m, blend_m=2.0), taper_scale=True,
+    )
+    return scatter_obj
+
+
+def apply_ground_cover(terrain, buffer_m=2.2):
+    """A second, finer ground layer (small monocots / clovers) for density."""
+    from infinigen.assets.scatters import flowerplant
+
+    try:
+        flowerplant.Flowerplant().apply(
+            terrain, selection=offroad_noise_selection(buffer_m, thresh=0.6)
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"ground cover skipped: {e}")
+
+
+# --------------------------------------------------------------------------- #
+# Rocks: scattered pebbles + the exact xodr boulders
+# --------------------------------------------------------------------------- #
+def apply_pebbles(terrain, buffer_m=2.0):
+    from infinigen.assets.scatters import pebbles
+
+    logger.info("scattering pebbles (off-corridor, patchy)...")
+    try:
+        pebbles.Pebbles().apply(
+            terrain, selection=offroad_noise_selection(buffer_m, noise_scale=0.12, thresh=0.55)
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"pebbles skipped: {e}")
+
+
+def place_boulders(road, collection_name="offroad_boulders"):
+    """Place the exact xodr <objects> boulders as real rocks at their world pos."""
+    from infinigen.assets.objects import rocks
+
+    col = butil.get_collection(collection_name)
+    placed = []
+    for i, o in enumerate(road.obstacles):
+        try:
+            fac = rocks.BoulderFactory(int(1000 + i), coarse=False)
+            obj = fac.spawn_asset(i)
+            obj.location = (o["x"], o["y"], o["z"] - 0.15)
+            r = max(0.2, o["radius"])
+            obj.scale = (r, r, r * U(0.7, 1.0))
+            obj.rotation_euler = (0, 0, U(0, 6.28))
+            butil.put_in_collection(obj, col)
+            placed.append(obj)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"boulder {o['id']} skipped: {e}")
+    logger.info(f"placed {len(placed)} xodr boulders")
+    return placed
+
+
+def apply_fern(terrain, buffer_m=2.5):
+    from infinigen.assets.scatters import fern
+
+    try:
+        fern.Fern().apply(terrain, selection=offroad_noise_selection(buffer_m, thresh=0.55))
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"fern skipped: {e}")
+
+
+# --------------------------------------------------------------------------- #
+# Generic placeholder->populate scatter for any AssetFactory (trees, cactus, ...)
+# --------------------------------------------------------------------------- #
+def _scatter_factory(terrain, factory_cls, n, label, buffer_m, altitude=-0.05, blend=3.0):
+    from infinigen.core.placement import placement
+
+    if n <= 0:
+        return None
+    logger.info(f"scattering {n} {label}...")
+    seed = int(np.random.randint(1e6))
+    fac_coarse = factory_cls(seed, coarse=True)
+    col = placement.scatter_placeholders_mesh(
+        terrain, fac_coarse, overall_density=1.0, num_placeholders=n,
+        selection=offroad_selection(buffer_m, blend_m=blend), altitude=altitude,
+    )
+    fac_fine = factory_cls(seed, coarse=False)
+    new = placement.populate_collection(fac_fine, col, cameras=None)
+    logger.info(f"  populated {len(new[0])} {label}")
+    return new
+
+
+def scatter_trees(terrain, road, n_trees=18, n_bushes=40, buffer_m=3.0):
+    from infinigen.assets.objects import trees
+
+    for cls, n, lbl in [(trees.BushFactory, n_bushes, "bushes"), (trees.TreeFactory, n_trees, "trees")]:
+        try:
+            _scatter_factory(terrain, cls, n, lbl, buffer_m)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"{lbl} skipped: {e}")
+
+
+def scatter_cactus(terrain, road, n=14, buffer_m=3.0):
+    from infinigen.assets.objects.cactus import CactusFactory
+
+    try:
+        _scatter_factory(terrain, CactusFactory, n, "cactus", buffer_m)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"cactus skipped: {e}")
+
+
+def scatter_extra_boulders(terrain, road, n=40, buffer_m=1.5):
+    from infinigen.assets.objects import rocks
+
+    try:
+        _scatter_factory(terrain, rocks.BoulderFactory, n, "boulders", buffer_m, altitude=-0.2)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"extra boulders skipped: {e}")
+
+
+# --------------------------------------------------------------------------- #
+# Snow: white terrain + snow surface layer on terrain & assets
+# --------------------------------------------------------------------------- #
+def apply_snow(terrain):
+    import bpy
+
+    from infinigen.assets.scatters import snow_layer
+
+    try:
+        snow = snow_layer.Snowlayer()
+        snow.apply(terrain)  # terrain-only (per-asset application is too slow)
+        logger.info("snow layer applied to terrain")
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"snow layer skipped: {e}")
+
+
+# --------------------------------------------------------------------------- #
+# Biome dispatcher
+# --------------------------------------------------------------------------- #
+def populate_biome(preset: dict, terrain, road, buffer_m):
+    toks = preset.get("scatters", [])
+    if "grass" in toks:
+        apply_grass(terrain, buffer_m, vol_density=preset.get("grass_density", 2.5))
+    if "grass_sparse" in toks:
+        apply_grass(terrain, buffer_m + 2.0, vol_density=0.3)  # sparse alpine grass
+    if "ground_cover" in toks:
+        apply_ground_cover(terrain, buffer_m)
+    if "fern" in toks:
+        apply_fern(terrain, buffer_m)
+    if "pebbles" in toks:
+        apply_pebbles(terrain, road.width * 0.5)
+    if "cactus" in toks:
+        scatter_cactus(terrain, road, n=preset.get("cactus_n", 14), buffer_m=buffer_m + 1.0)
+    if "boulders_extra" in toks:
+        scatter_extra_boulders(terrain, road, n=preset.get("boulder_n", 40), buffer_m=road.width * 0.5 + 0.5)
+    if "trees" in toks or "trees_dense" in toks:
+        scatter_trees(terrain, road, n_trees=preset.get("tree_n", 12),
+                      n_bushes=preset.get("bush_n", 36), buffer_m=buffer_m + 1.0)
+    place_boulders(road)  # the exact xodr boulders, always
+    if "snow_layer" in toks:
+        apply_snow(terrain)


### PR DESCRIPTION
Generate detailed off-road driving scenes from a given .xodr road, where the environment conforms to the road (path-first, "environment follows road") rather than the road being draped onto independently-generated terrain. Built as a standalone package that uses Infinigen as an asset/material/lighting library; it deliberately does NOT use Infinigen's C/CUDA terrain SDF pipeline.

Pipeline (offroad/build_scene.py):
- road_spec.from_xodr: parse OpenDRIVE planView + elevationProfile + lane widths + <objects> into a 3D centerline, width and boulders.
- conform_terrain: road-anchored heightfield H = z_road + noise*falloff(dist), so terrain == road elevation on the carriageway (conform error 0.0, no walls) and natural relief grows away from the road; distance-weighted elevation removes the winding-road seam.
- build_terrain: ground mesh + baked dist_to_road/z_road/road_falloff attrs.
- vegetation: off-corridor scatter masks (read dist_to_road) for grass, rocks, trees/bushes, cactus, ferns; places the exact xodr boulders.
- road_surface: high-res (s,t) dirt road mesh with wheel ruts, washboard, potholes and mud patches from spec.json features + per-face dirt/mud material.
- biomes: presets (grassland/desert/mountain/snow/forest) selecting relief, terrain material, lighting and scatter set; the conforming core is biome-agnostic (conform error 0.0 for all).

Verified: all five biomes render from the same grassland xodr.