### PR TITLE
fix: pin setuptools to <81.0.0 for landlab 2.6.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy", "Cython"]
+requires = ["setuptools<81.0.0", "numpy", "Cython"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -48,6 +48,8 @@ dependencies = [
     # used by trimesh, we could specify "trimesh[easy]" but this brings more packages
     "python-fcl",
     "rtree",
+
+    "setuptools<81.0.0",
 ]
 
 [project.optional-dependencies]
@@ -56,7 +58,7 @@ terrain = [
     "pyrender<0.2.0",
     # landlab depends on `setuptools` but doesn't explicitly list it as a
     # dependency; We include it to avoid problems with newer Python versions.
-    "setuptools"
+    "setuptools<81.0.0"
 ]
 vis = [
     "einops",


### PR DESCRIPTION
- landlab 2.6.0 requires pkg_resources at runtime
- setuptools 81.0.0+ removed pkg_resources with no backward compatibility
- This pin ensures pkg_resources remains available
- landlab 2.11.0+ fixes this but requires Python 3.12 (incompatible with Infinigen's Python 3.11 requirement)

Fixes: #501