### PR TITLE
Fix room_walls TypeError for wall materials without **kwargs

### DIFF
--- a/src/infinigen/core/constraints/example_solver/room/decorate.py
+++ b/src/infinigen/core/constraints/example_solver/room/decorate.py
@@ -7,6 +7,7 @@
 # - Karhan Kayan: fix constants
 
 import importlib
+import inspect
 import logging
 import os
 from collections import defaultdict
@@ -220,6 +221,12 @@ def room_walls(walls: list[bpy.types.Object], constants: RoomConstants, n_walls=
     for wall_fn in set(wall_fns):
         shape = np.random.choice(["square", "rectangle", "hexagon"])
         kwargs = dict(vertical=True, alternating=False, shape=shape)
+        # Only pass tile kwargs to generators that accept them; several wall
+        # materials (e.g. Concrete, Ceramic, Brick) define generate(self) with
+        # no **kwargs and would otherwise raise TypeError.
+        params = inspect.signature(wall_fn.generate).parameters.values()
+        if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
+            kwargs = {}
         rooms_ = [o for o, w in zip(walls, wall_fns) if w == wall_fn]
         indices = np.random.randint(0, n_walls, len(rooms_))
         for i in range(n_walls):
@@ -227,8 +234,6 @@ def room_walls(walls: list[bpy.types.Object], constants: RoomConstants, n_walls=
             if wall_fn.__class__.__name__ == "Plaster":
                 for r in rooms__:
                     unwrap_normal(r, selection=None)
-            if wall_fn.__class__.__name__ == "Brick":
-                kwargs = {}
             surface.assign_material(rooms__, wall_fn(**kwargs))
 
     for w in walls:

--- a/tests/infinigen/solver/test_room_wall_materials.py
+++ b/tests/infinigen/solver/test_room_wall_materials.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2024, Princeton University.
+# This source code is licensed under the BSD 3-Clause license found in the LICENSE file in the root directory of this source tree.
+
+import inspect
+
+import pytest
+
+from infinigen.assets.composition import material_assignments
+
+
+def wall_material_classes():
+    lists = [
+        material_assignments.wall,
+        material_assignments.kitchen_wall,
+        material_assignments.garage_wall,
+        material_assignments.utility_wall,
+        material_assignments.balcony_wall,
+        material_assignments.bathroom_wall,
+        material_assignments.warehouse_wall,
+    ]
+    seen = {}
+    for weighted in lists:
+        for cls, _ in weighted:
+            seen[cls.__name__] = cls
+    return list(seen.values())
+
+
+@pytest.mark.parametrize("wall_cls", wall_material_classes())
+def test_wall_material_accepts_room_walls_kwargs(wall_cls):
+    # room_walls() gates the tile kwargs on whether generate() accepts **kwargs;
+    # replicate that gate and assert the resulting call binds. Passing the tile
+    # kwargs unconditionally raised TypeError for Concrete/Brick etc. (issue #505).
+    sig = inspect.signature(wall_cls.generate)
+    kwargs = dict(vertical=True, alternating=False, shape="square")
+    if not any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    ):
+        kwargs = {}
+    sig.bind(None, **kwargs)  # None stands in for the unbound `self`
+
+
+def test_concrete_wall_rejects_tile_kwargs_without_gate():
+    # Guards the premise of the gate: Concrete.generate has no **kwargs, so the
+    # old unconditional room_walls() call crashed on garage/utility/warehouse walls.
+    from infinigen.assets.materials.ceramic.concrete import Concrete
+
+    sig = inspect.signature(Concrete.generate)
+    with pytest.raises(TypeError):
+        sig.bind(None, vertical=True, alternating=False, shape="square")


### PR DESCRIPTION
## Author Requirements

Write a short answer in each description, then change the box to be `[x]` to complete it
(you can also click the boxes after creating the PR)

### What does the PR do?

What GitHub issue is this working on? If the issue is done, say "Fixes #X".
- [x] Fixes #505

Description of what was changed in this specific PR
- [x] `room_walls()` unconditionally passed the tile kwargs (`vertical`, `alternating`, `shape`) to every selected wall material generator, special-casing only `Brick` with `kwargs = {}`. Materials like `Concrete`, `Ceramic`, `MarbleRegular` and `MarbleVoronoi` define `generate(self)` without `**kwargs`, so garage/utility/warehouse walls (which include `Concrete`/`Brick`) crashed with `TypeError: Concrete.generate() got an unexpected keyword argument 'vertical'`. The call now only forwards the kwargs when `generate` accepts `**kwargs`, which also removes the `Brick` name check (and the latent bug where `kwargs = {}` leaked into later loop iterations).

### Outside sources

List ALL sources consulted to implement the PR that were not written by you, e.g. youtube videos, stackoverflow, any websites at all.

- [x] List all outside sources sources:
    - None

### Tests

*We will not merge if your branch does not show green checkmark*
It will fail if you have bad linting or formatting, but these should already be checked locally by `pre-commit`

Please run `uv run pytest tests/infinigen2` if you changed any core tools (outside of a specific asset)

### Results

- [x] Paste your render or unit test command(s):
    - `uv run pytest tests/infinigen/solver/test_room_wall_materials.py`
    - Added `tests/infinigen/solver/test_room_wall_materials.py`, which checks every wall material in `material_assignments` can be called with the kwargs `room_walls()` produces, and asserts `Concrete.generate` rejects those kwargs without the gate.

- [x] Paste images and commands to demonstrate the results of the PR:
    - N/A (bugfix; no visual change)

## Reviewer Requirements

1. Check for unsafe or unmaintainable code
2. Check for accidental new files or unnecessary edits (e.g. formatting, unrelated changes in PR)
3. If there are any "Outside Sources" you *must* request review from `araistrick`
